### PR TITLE
Refactor puzzle into modular components with routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@tailwindcss/vite": "^4.1.11",
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,13 @@
-import { useState } from 'react'
-import './App.css'
-
-import Puzzle from "./Puzzle";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import "./App.css";
+import Home from "./pages/Home.jsx";
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-100">
-      <Puzzle />
-    </div>
+    <Router>
+      <Routes>
+        <Route path="/" element={<Home />} />
+      </Routes>
+    </Router>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,9 @@
+import Puzzle from "../puzzle/Puzzle.jsx";
+
+export default function Home() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <Puzzle />
+    </div>
+  );
+}

--- a/src/puzzle/constants.js
+++ b/src/puzzle/constants.js
@@ -1,0 +1,34 @@
+export const GRID_COLS = 12;
+export const GRID_ROWS = 12;
+export const QUEUE_SIZE = 4;
+export const CELL_MIN = 20;  // minimum cell px when auto-scaling
+export const CELL_MAX = 64;  // maximum cell px when auto-scaling
+export const CLEAR_MS = 280; // duration of clear flash/shrink
+export const SHIFT_MS = 320; // duration of board shift animation
+export const COMBO_MS = 900; // combo popup lifetime
+export const BURST_MS = 1000; // score burst lifetime
+
+export const SHAPES = [
+  { key: "single", name: "1×1", color: "bg-emerald-500", flash: "bg-emerald-200", blocks: [[0, 0]] },
+  { key: "line2",  name: "1×2", color: "bg-sky-400",     flash: "bg-sky-200",     blocks: [[0, 0], [1, 0]] },
+  { key: "line3",  name: "1×3", color: "bg-amber-500",   flash: "bg-amber-200",   blocks: [[0, 0], [1, 0], [2, 0]] },
+  { key: "line4",  name: "1×4", color: "bg-rose-500",    flash: "bg-rose-200",    blocks: [[0, 0], [1, 0], [2, 0], [3, 0]] },
+  { key: "square2",name: "2×2", color: "bg-violet-500",  flash: "bg-violet-200",  blocks: [[0, 0], [1, 0], [0, 1], [1, 1]] },
+  { key: "square3",name: "3×3", color: "bg-cyan-500",    flash: "bg-cyan-200",    blocks: [[0,0],[1,0],[2,0],[0,1],[1,1],[2,1],[0,2],[1,2],[2,2]] },
+  { key: "corner2",name: "Corner 2×2", color: "bg-yellow-500", flash: "bg-yellow-200", blocks: [[0,0],[1,0],[0,1]] },
+  { key: "t3",     name: "T",   color: "bg-teal-400",    flash: "bg-teal-200",    blocks: [[0,0],[1,0],[2,0],[1,1]] },
+  { key: "L3",     name: "L",   color: "bg-lime-400",    flash: "bg-lime-200",    blocks: [[0,0],[0,1],[0,2],[1,2]] },
+  { key: "Z",      name: "Z",   color: "bg-rose-400",    flash: "bg-rose-200",    blocks: [[0,0],[1,0],[1,1],[2,1]] },
+];
+
+export const FLASH_BY_COLOR = SHAPES.reduce((acc, s) => {
+  acc[s.color] = s.flash || deriveFlashClass(s.color);
+  return acc;
+}, {});
+
+export function deriveFlashClass(base) {
+  const m = /^bg-([a-z-]+)-(\d{2,3})$/.exec(base);
+  if (!m) return "bg-white";
+  const [_, hue] = m;
+  return `bg-${hue}-200`;
+}

--- a/src/puzzle/geometry.js
+++ b/src/puzzle/geometry.js
@@ -1,0 +1,44 @@
+export function normalize(blocks) {
+  let minX = Infinity, minY = Infinity;
+  for (const [x, y] of blocks) {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+  }
+  return blocks.map(([x, y]) => [x - minX, y - minY]);
+}
+
+export function rotateCW(blocks) {
+  const { h } = shapeSize(blocks);
+  const rotated = blocks.map(([x, y]) => [h - 1 - y, x]);
+  return normalize(rotated);
+}
+
+export function rotate(blocks, steps) {
+  let out = blocks;
+  for (let i = 0; i < ((steps % 4) + 4) % 4; i++) out = rotateCW(out);
+  return out;
+}
+
+export function mirror(blocks) {
+  const { w } = shapeSize(blocks);
+  const mirrored = blocks.map(([x, y]) => [w - 1 - x, y]);
+  return normalize(mirrored);
+}
+
+export function applyOrientation(blocks, rotation, isMirrored) {
+  let oriented = rotate(blocks, rotation);
+  if (isMirrored) oriented = mirror(oriented);
+  return oriented;
+}
+
+export function shapeSize(blocks) {
+  const xs = blocks.map(b => b[0]);
+  const ys = blocks.map(b => b[1]);
+  return { w: Math.max(...xs) + 1, h: Math.max(...ys) + 1 };
+}
+
+export function nextOrientation(rotation, isMirrored) {
+  const nextRot = (rotation + 1) % 4;
+  const nextMir = nextRot === 0 ? !isMirrored : isMirrored;
+  return { rotation: nextRot, isMirrored: nextMir };
+}

--- a/src/puzzle/grid.js
+++ b/src/puzzle/grid.js
@@ -1,0 +1,66 @@
+import { GRID_ROWS, GRID_COLS } from './constants.js';
+
+export function emptyGrid() {
+  return Array.from({ length: GRID_ROWS }, () => Array.from({ length: GRID_COLS }, () => null));
+}
+
+export function computeClears(g) {
+  const rowsFull = new Set();
+  const colsFull = new Set();
+
+  for (let r = 0; r < GRID_ROWS; r++) {
+    let full = true;
+    for (let c = 0; c < GRID_COLS; c++) {
+      if (!g[r][c]) { full = false; break; }
+    }
+    if (full) rowsFull.add(r);
+  }
+
+  for (let c = 0; c < GRID_COLS; c++) {
+    let full = true;
+    for (let r = 0; r < GRID_ROWS; r++) {
+      if (!g[r][c]) { full = false; break; }
+    }
+    if (full) colsFull.add(c);
+  }
+
+  let topShift = 0;
+  while (rowsFull.has(topShift)) topShift++;
+  let bottomShift = 0;
+  while (rowsFull.has(GRID_ROWS - 1 - bottomShift)) bottomShift++;
+
+  let leftShift = 0;
+  while (colsFull.has(leftShift)) leftShift++;
+  let rightShift = 0;
+  while (colsFull.has(GRID_COLS - 1 - rightShift)) rightShift++;
+
+  return { rowsFull, colsFull, topShift, bottomShift, leftShift, rightShift };
+}
+
+export function clearOnly(g, rowsFull, colsFull) {
+  return g.map((row, r) => row.map((cell, c) => (rowsFull.has(r) || colsFull.has(c)) ? null : cell));
+}
+
+export function applyClearsAndShifts(g, rowsFull, colsFull, shifts) {
+  const { topShift, bottomShift, leftShift, rightShift } = shifts;
+  let afterClear = clearOnly(g, rowsFull, colsFull);
+
+  const dx = -leftShift + rightShift;
+  const dy = -topShift + bottomShift;
+
+  if (dx === 0 && dy === 0) return afterClear;
+
+  const out = emptyGrid();
+  for (let r = 0; r < GRID_ROWS; r++) {
+    for (let c = 0; c < GRID_COLS; c++) {
+      const cell = afterClear[r][c];
+      if (!cell) continue;
+      const nr = r + dy;
+      const nc = c + dx;
+      if (nr >= 0 && nr < GRID_ROWS && nc >= 0 && nc < GRID_COLS) {
+        out[nr][nc] = cell;
+      }
+    }
+  }
+  return out;
+}

--- a/src/puzzle/rng.js
+++ b/src/puzzle/rng.js
@@ -1,0 +1,18 @@
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6D2B79F5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function makeRng(seed) {
+  const rand = mulberry32(seed);
+  return {
+    next: () => rand(),
+    int: (max) => Math.floor(rand() * max),
+    choice: (arr) => arr[Math.floor(rand() * arr.length)],
+  };
+}


### PR DESCRIPTION
## Summary
- Modularize puzzle utilities into dedicated modules for constants, geometry, grid logic, and RNG
- Introduce Home page and React Router setup for future multi-page support
- Move Puzzle component into its own folder and update imports accordingly

## Testing
- `npm run lint` *(fails: React Hook dependency warnings but no errors; dependency install for react-router-dom was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68962b4801088320a34b3f113e506077